### PR TITLE
Lexer: Possible bugfix

### DIFF
--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -443,8 +443,11 @@ impl Lexer {
     }
 
     fn peek(&self) -> char {
-        if self.is_at_end() { '\0'; }
-        self.char_at(0)
+        if self.is_at_end() {
+            '\0'
+        } else {
+            self.char_at(0)
+        }
     }
 
     fn next(&self) -> char {


### PR DESCRIPTION
The `if` statement never returned a value, so `self.char_at` is always executed.