### PR TITLE
VM: Implement `std.io.flush()`

### DIFF
--- a/libs/std/std_io.wt
+++ b/libs/std/std_io.wt
@@ -17,6 +17,11 @@ unit io {
     native print -> 'io@print'
 
     /*
+     Выводит буферизованные данные на экран.
+    */
+    native flush -> 'io@flush'
+
+    /*
      Запрашивает ввод у пользователя.
     */
     native input -> 'io@input'

--- a/src/vm/natives/libs/natives_io.rs
+++ b/src/vm/natives/libs/natives_io.rs
@@ -1,5 +1,5 @@
 ﻿// импорты
-use std::io;
+use std::io::{self, Write};
 use crate::error;
 use crate::errors::errors::Error;
 use crate::lexer::address::Address;
@@ -36,6 +36,21 @@ pub unsafe fn provide(built_in_address: Address, vm: &mut VM) -> Result<(), Erro
             if should_push {
                 vm.push(Value::Null)
             }
+            Ok(())
+        }
+    );
+    natives::provide(
+        vm,
+        built_in_address.clone(),
+        0,
+        "io@flush".to_string(),
+        |vm: &mut VM, addr: Address, should_push: bool, table: *mut Table, owner: *mut FnOwner| {
+            std::io::stdout().lock().flush().unwrap();
+
+            if should_push {
+                vm.push(Value::Null)
+            }
+            
             Ok(())
         }
     );


### PR DESCRIPTION
This function flushes the `stdout` buffer.

It can be used in programs that request user info, like this:
```
import 'std.io'

io.print('Whats your name: ')

name := io.input()

io.println('Hello, ' + name)
```

But this program won't work, because `Whats your name: ` is not being flushed, which results in:
```
Lloyd
Whats your name: Hello, Lloyd
```

But after adding `io.flush` after `io.print` everything becomes fine:
```diff
io.print('Whats your name: ')
- 
+ io.flush()
```

Program output:
```
Whats your name: Lloyd
Hello, Lloyd
```