### PR TITLE
Refactors leading to memory optimizations (again)

### DIFF
--- a/src/compiler/visitor.rs
+++ b/src/compiler/visitor.rs
@@ -218,10 +218,10 @@ impl CompileVisitor {
     }
 
     // блок
-    fn visit_block(&mut self, body: Vec<Box<Node>>) {
+    fn visit_block(&mut self, body: Vec<Node>) {
         // перебор и компиляция нод
         for node in body {
-            self.visit_node(*node)
+            self.visit_node(node)
         }
     }
 
@@ -373,7 +373,7 @@ impl CompileVisitor {
         &mut self,
         previous: Option<Box<Node>>,
         name: Token,
-        args: Vec<Box<Node>>,
+        args: Vec<Node>,
         should_push: bool,
     ) {
         // есть ли предыдущая нода
@@ -474,7 +474,7 @@ impl CompileVisitor {
     }
 
     // визит инициализатора списка
-    fn visit_list(&mut self, location: Token, list: Box<Vec<Node>>) {
+    fn visit_list(&mut self, location: Token, list: Vec<Node>) {
         // создаём список
         self.push_instr(Opcode::Instance {
             addr: location.address.clone(),
@@ -485,7 +485,7 @@ impl CompileVisitor {
         // если длина больше нуля
         if (*list).len() > 0 {
             // заполняем
-            for item in *list {
+            for item in list {
                 // дублируем список
                 self.push_instr(Opcode::Duplicate {
                     addr: location.address.clone(),
@@ -604,7 +604,7 @@ impl CompileVisitor {
         &mut self,
         location: Token,
         matchable: Box<Node>,
-        cases: Vec<Box<Node>>,
+        cases: Vec<Node>,
         default: Box<Node>,
     ) {
         todo!()
@@ -829,13 +829,13 @@ impl CompileVisitor {
     fn visit_instance(
         &mut self,
         name: Token,
-        constructor: Vec<Box<Node>>,
+        constructor: Vec<Node>,
         should_push: bool,
     ) {
         // конструктор
         self.push_chunk();
         for arg in constructor {
-            self.visit_node(*arg);
+            self.visit_node(arg);
         }
         let constructor_args = self.pop_chunk();
         // инстанс

--- a/src/compiler/visitor.rs
+++ b/src/compiler/visitor.rs
@@ -197,7 +197,7 @@ impl CompileVisitor {
                 self.visit_unit(name, full_name, body);
             }
             Node::For { iterable, variable_name, body, } => {
-                self.visit_for(iterable, variable_name, body);
+                self.visit_for(*iterable, variable_name, body);
             }
             Node::Block { body } => {
                 self.visit_block(body);
@@ -512,7 +512,7 @@ impl CompileVisitor {
     fn visit_map(
         &mut self,
         location: Token,
-        map: Box<Vec<(Box<Node>, Box<Node>)>>,
+        map: Vec<(Box<Node>, Box<Node>)>,
     ) {
         todo!()
     }
@@ -520,13 +520,13 @@ impl CompileVisitor {
     // цикл for
     fn visit_for(
         &mut self,
-        iterable: Box<Node>,
+        iterable: Node,
         variable_name: Token,
         body: Box<Node>,
     ) {
         // чанк итератора
         self.push_chunk();
-        self.visit_node(*iterable);
+        self.visit_node(iterable);
         let iterator_chunk = self.pop_chunk();
         // имя для временной переменной
         let iterator_variable_name = format!("@{}", variable_name.value.clone());

--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -33,7 +33,7 @@ pub unsafe fn run(
     // компиляция
     let tokens = lex(
         filename,
-        code,
+        &code,
         lexer_debug.unwrap_or(false),
         lexer_bench.unwrap_or(false)
     );
@@ -89,7 +89,7 @@ pub fn read_file(addr: Option<Address>, path: &PathBuf) -> String {
                     )
                 );
             }
-            "".to_string()
+            String::new()
         }
     }
     // если нет
@@ -113,7 +113,7 @@ pub fn read_file(addr: Option<Address>, path: &PathBuf) -> String {
 }
 
 // лексинг
-pub fn lex(file_name: &str, code: String, debug: bool, bench: bool) -> Option<Vec<Token>> {
+pub fn lex(file_name: &str, code: &str, debug: bool, bench: bool) -> Option<Vec<Token>> {
     // начальное время
     let start = std::time::Instant::now();
     // сканнинг токенов

--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -181,7 +181,7 @@ pub fn parse(file_name: &str, tokens: Vec<Token>,
 // семантический анализ
 pub fn analyze(ast: Node) -> Node {
     // анализ
-    let analyzed = Analyzer::new().analyze(ast);
+    let analyzed = Analyzer::new().analyze(&ast);
     // возвращаем
     analyzed
 }

--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -193,12 +193,15 @@ pub unsafe fn compile(ast: Node, opcodes_debug: bool, bench: bool) -> Chunk {
     // компилируем
     let compiled = CompileVisitor::new().compile(ast);
     // конечное время
-    let duration = start.elapsed().as_nanos();
-    if bench { println!("benchmark 'compile', elapsed {}", duration as f64 / 1_000_000f64); }
+    if bench {
+        let duration = start.elapsed().as_nanos();
+        
+        println!("benchmark 'compile', elapsed {}", duration as f64 / 1_000_000f64);
+    }
     // дебаг
     if opcodes_debug {
         println!("opcodes debug: ");
-        println!("{:?}", compiled.clone());
+        println!("{:?}", &compiled);
     }
     // возвращаем
     compiled

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -1,69 +1,69 @@
 ﻿// импорты
-use std::collections::HashMap;
 use crate::error;
+use crate::errors::errors::Error;
 use crate::lexer::address::*;
-use crate::errors::errors::{Error};
+use std::collections::HashMap;
 
 // тип токена
 #[derive(Debug, Clone, Eq, PartialEq, Copy, Hash)]
 #[allow(dead_code)]
 pub enum TokenType {
     Fun,
-    Op, // +, -, *, /
-    Lparen, // (
-    Rparen, // )
-    Lbrace, // {
-    Rbrace, // }
-    Lambda, // lambda
-    Walrus, // :=
-    Eq, // ==
-    NotEq, // !=
-    Text, // 'text'
-    Number, // 1234567890.0123456789
-    Assign, // =
-    Id, // variable id
-    Comma, // ,
-    Ret, // return
-    If, // if
-    Bool, // bool
-    While, // while
-    Type, // type
-    New, // new
-    Dot, // dot
-    Greater, // >
-    Less,  // <
+    Op,        // +, -, *, /
+    Lparen,    // (
+    Rparen,    // )
+    Lbrace,    // {
+    Rbrace,    // }
+    Lambda,    // lambda
+    Walrus,    // :=
+    Eq,        // ==
+    NotEq,     // !=
+    Text,      // 'text'
+    Number,    // 1234567890.0123456789
+    Assign,    // =
+    Id,        // variable id
+    Comma,     // ,
+    Ret,       // return
+    If,        // if
+    Bool,      // bool
+    While,     // while
+    Type,      // type
+    New,       // new
+    Dot,       // dot
+    Greater,   // >
+    Less,      // <
     GreaterEq, // >=
-    LessEq, // <=
-    Null, // null
-    Elif, // elif
-    Else, // else
-    And, // logical and
-    Or, // logical or
-    Import, // import
+    LessEq,    // <=
+    Null,      // null
+    Elif,      // elif
+    Else,      // else
+    And,       // logical and
+    Or,        // logical or
+    Import,    // import
     AssignAdd, // assign add
     AssignSub, // assign sub
     AssignMul, // assign mul
-    AssignDiv,  // assign divide
-    Break, // break
-    Match, // match
-    Case, // case
-    Default, // default
-    Lbracket, // [
-    Rbracket, // ]
-    Colon, // colon :
-    For, // for
-    Bang, // !
-    In, // in
-    Continue, // continue
-    Arrow, // ->
-    Unit, // unit
-    Native, // native
-    With, // with
-    Trait, // trait
-    Impl, // impl
-    Question, // ?
-    Impls, // impls
-    Range // ..
+    AssignDiv, // assign divide
+    Break,     // break
+    Match,     // match
+    Case,      // case
+    Default,   // default
+    Lbracket,  // [
+    Rbracket,  // ]
+    Colon,     // colon :
+    For,       // for
+    Bang,      // !
+    In,        // in
+    Continue,  // continue
+    Arrow,     // ->
+    Unit,      // unit
+    Native,    // native
+    With,      // with
+    Trait,     // trait
+    Impl,      // impl
+    Question,  // ?
+    Impls,     // impls
+    Range,     // ..
 }
 
 // токен
@@ -76,24 +76,28 @@ pub struct Token {
 // имплементация
 impl Token {
     pub fn new(tk_type: TokenType, value: String, address: Address) -> Token {
-        Token { tk_type, value, address }
+        Token {
+            tk_type,
+            value,
+            address,
+        }
     }
 }
 
 // лексер
-pub struct Lexer {
+pub struct Lexer<'filename> {
     line: u64,
     column: u16,
     current: u128,
     line_text: String,
     code: Vec<char>,
-    filename: String,
+    filename: &'filename str,
     tokens: Vec<Token>,
     keywords: HashMap<String, TokenType>,
 }
 // имплементация
-impl Lexer {
-    pub fn new(code: String, filename: &str) -> Lexer {
+impl<'filename> Lexer<'filename> {
+    pub fn new(code: &str, filename: &'filename str) -> Lexer<'filename> {
         let map = HashMap::from([
             (String::from("fun"), TokenType::Fun),
             (String::from("break"), TokenType::Break),
@@ -128,11 +132,11 @@ impl Lexer {
             line: 1,
             current: 0,
             column: 0,
-            line_text: "".to_string(),
+            line_text: String::new(),
             code: code.chars().collect::<Vec<char>>(),
-            filename: filename.to_string(),
+            filename: filename,
             tokens: vec![],
-            keywords: map
+            keywords: map,
         };
         // текст первой линии
         lexer.line_text = lexer.get_line_text();
@@ -140,7 +144,7 @@ impl Lexer {
         lexer
     }
 
-    pub fn lex(&mut self) -> Vec<Token>{
+    pub fn lex(&mut self) -> Vec<Token> {
         while !self.is_at_end() {
             let ch = self.advance();
             match ch {
@@ -193,43 +197,42 @@ impl Lexer {
                 }
                 '(' => {
                     self.add_tk(TokenType::Lparen, "(".to_string());
-                },
+                }
                 ')' => {
                     self.add_tk(TokenType::Rparen, ")".to_string());
-                },
+                }
                 '{' => {
                     self.add_tk(TokenType::Lbrace, "{".to_string());
-                    
-                },
+                }
                 '}' => {
                     self.add_tk(TokenType::Rbrace, "}".to_string());
-                },
+                }
                 '[' => {
                     self.add_tk(TokenType::Lbracket, "[".to_string());
-                },
+                }
                 ']' => {
                     self.add_tk(TokenType::Rbracket, "]".to_string());
-                },
+                }
                 ',' => {
                     self.add_tk(TokenType::Comma, ",".to_string());
-                },
+                }
                 '.' => {
                     if self.is_match('.') {
                         self.add_tk(TokenType::Range, "..".to_string());
                     } else {
                         self.add_tk(TokenType::Dot, ".".to_string());
                     }
-                },
+                }
                 '?' => {
                     self.add_tk(TokenType::Question, "?".to_string());
-                },
+                }
                 ':' => {
                     if self.is_match('=') {
                         self.add_tk(TokenType::Walrus, ":=".to_string());
                     } else {
                         self.add_tk(TokenType::Colon, ":".to_string())
                     }
-                },
+                }
                 '<' => {
                     if self.is_match('=') {
                         self.add_tk(TokenType::LessEq, "<=".to_string());
@@ -266,16 +269,14 @@ impl Lexer {
                     self.newline();
                 }
                 ' ' => {}
-                '\'' => {
-                    match self.scan_string() {
-                        Ok(tk) => {
-                            self.tokens.push(tk);
-                        }
-                        Err(err) => {
-                            error!(err);
-                        }
+                '\'' => match self.scan_string() {
+                    Ok(tk) => {
+                        self.tokens.push(tk);
                     }
-                }
+                    Err(err) => {
+                        error!(err);
+                    }
+                },
                 _ => {
                     if self.is_digit(ch) {
                         match self.scan_number(ch) {
@@ -286,17 +287,15 @@ impl Lexer {
                                 error!(err);
                             }
                         }
-                    }
-                    else if self.is_id(ch) {
+                    } else if self.is_id(ch) {
                         let token = self.scan_id_or_keyword(ch);
                         self.tokens.push(token);
-                    }
-                    else {
+                    } else {
                         error!(Error::new(
                             Address::new(
                                 self.line,
                                 self.column,
-                                self.filename.clone(),
+                                self.filename.to_string(),
                                 self.line_text.clone(),
                             ),
                             format!("unexpected char: {}", ch),
@@ -314,18 +313,16 @@ impl Lexer {
         while self.peek() != '\'' {
             text.push(self.advance());
             if self.is_at_end() || self.is_match('\n') {
-                return Err(
-                    Error::new(
-                        Address::new(
-                            self.line,
-                            self.column,
-                            self.filename.clone(),
-                            self.line_text.clone(),
-                        ),
-                        "unclosed string quotes.".to_string(),
-                        "did you forget ' symbol?".to_string(),
-                    )
-                )
+                return Err(Error::new(
+                    Address::new(
+                        self.line,
+                        self.column,
+                        self.filename.to_string(),
+                        self.line_text.clone(),
+                    ),
+                    "unclosed string quotes.".to_string(),
+                    "did you forget ' symbol?".to_string(),
+                ));
             }
         }
         self.advance();
@@ -335,7 +332,7 @@ impl Lexer {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.clone(),
+                self.filename.to_string(),
                 self.line_text.clone(),
             ),
         })
@@ -347,21 +344,19 @@ impl Lexer {
         while self.is_digit(self.peek()) || self.peek() == '.' {
             if self.peek() == '.' {
                 if self.next() == '.' {
-                    break
+                    break;
                 }
                 if is_float {
-                    return Err(
-                        Error::new(
-                            Address::new(
-                                self.line,
-                                self.column,
-                                self.filename.clone(),
-                                self.line_text.clone(),
-                            ),
-                            "couldn't parse number with two dots".to_string(),
-                            "check your code.".to_string(),
-                        )
-                    )
+                    return Err(Error::new(
+                        Address::new(
+                            self.line,
+                            self.column,
+                            self.filename.to_string(),
+                            self.line_text.clone(),
+                        ),
+                        "couldn't parse number with two dots".to_string(),
+                        "check your code.".to_string(),
+                    ));
                 }
                 is_float = true;
                 text.push(self.advance());
@@ -369,7 +364,7 @@ impl Lexer {
             }
             text.push(self.advance());
             if self.is_at_end() {
-                break
+                break;
             }
         }
         Ok(Token {
@@ -378,7 +373,7 @@ impl Lexer {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.clone(),
+                self.filename.to_string(),
                 self.line_text.clone(),
             ),
         })
@@ -389,12 +384,12 @@ impl Lexer {
         while self.is_id(self.peek()) {
             text.push(self.advance());
             if self.is_at_end() {
-                break
+                break;
             }
         }
         let tk_type: TokenType = match self.keywords.get(&text) {
             Some(tk_type) => tk_type.clone(),
-            None => TokenType::Id
+            None => TokenType::Id,
         };
         Token {
             tk_type,
@@ -402,7 +397,7 @@ impl Lexer {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.clone(),
+                self.filename.to_string(),
                 self.line_text.clone(),
             ),
         }
@@ -471,8 +466,7 @@ impl Lexer {
     fn is_match(&mut self, ch: char) -> bool {
         if self.is_at_end() {
             false
-        }
-        else {
+        } else {
             if self.char_at(0) == ch {
                 self.advance();
                 true
@@ -483,16 +477,16 @@ impl Lexer {
     }
 
     fn add_tk(&mut self, tk_type: TokenType, tk_value: String) {
-        self.tokens.push(
-            Token::new(
-                tk_type, tk_value, Address::new(
-                    self.line,
-                    self.column,
-                    self.filename.clone(),
-                    self.line_text.clone(),
-                )
-            )
-        );
+        self.tokens.push(Token::new(
+            tk_type,
+            tk_value,
+            Address::new(
+                self.line,
+                self.column,
+                self.filename.to_string(),
+                self.line_text.clone(),
+            ),
+        ));
     }
 
     fn is_digit(&self, ch: char) -> bool {
@@ -500,13 +494,10 @@ impl Lexer {
     }
 
     fn is_letter(&self, ch: char) -> bool {
-        (ch >= 'a' && ch <= 'z') ||
-        (ch >= 'A' && ch <= 'Z') ||
-        (ch == '_')
+        (ch >= 'a' && ch <= 'z') || (ch >= 'A' && ch <= 'Z') || (ch == '_')
     }
 
     fn is_id(&self, ch: char) -> bool {
-        self.is_letter(ch) || self.is_digit(ch) ||
-        (ch == ':' && self.is_id(self.next()))
+        self.is_letter(ch) || self.is_digit(ch) || (ch == ':' && self.is_id(self.next()))
     }
 }

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -97,7 +97,7 @@ pub enum Node {
     },
     Map {
         location: Token,
-        values: Box<Vec<(Box<Node>, Box<Node>)>>,
+        values: Vec<(Box<Node>, Box<Node>)>,
     },
     Match {
         location: Token,

--- a/src/parser/ast.rs
+++ b/src/parser/ast.rs
@@ -8,7 +8,7 @@ use crate::errors::errors::Error;
 #[allow(dead_code)]
 pub enum Node {
     Block {
-        body: Vec<Box<Node>>,
+        body: Vec<Node>,
     },
     Number {
         value: Token,
@@ -57,7 +57,7 @@ pub enum Node {
     Call {
         previous: Option<Box<Node>>,
         name: Token,
-        args: Vec<Box<Node>>,
+        args: Vec<Node>,
         should_push: bool,
     },
     FnDeclaration {
@@ -83,7 +83,7 @@ pub enum Node {
     },
     List {
         location: Token,
-        values: Box<Vec<Node>>,
+        values: Vec<Node>,
     },
     Cond {
         left: Box<Node>,
@@ -102,7 +102,7 @@ pub enum Node {
     Match {
         location: Token,
         matchable: Box<Node>,
-        cases: Vec<Box<Node>>,
+        cases: Vec<Node>,
         default: Box<Node>,
     },
     Native {
@@ -111,7 +111,7 @@ pub enum Node {
     },
     Instance {
         name: Token,
-        constructor: Vec<Box<Node>>,
+        constructor: Vec<Node>,
         should_push: bool,
     },
     Ret {

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -414,8 +414,7 @@ impl<'filename> Parser<'filename> {
         }
         // заполненный
         else {
-            let mut nodes: Vec<Node> = Vec::new();
-            nodes.push(self.expr()?);
+            let mut nodes: Vec<Node> = vec![self.expr()?];
 
             while self.check(TokenType::Comma) {
                 self.consume(TokenType::Comma)?;
@@ -454,7 +453,7 @@ impl<'filename> Parser<'filename> {
             Ok(
                 Node::Map {
                     location,
-                    values: Box::new(Vec::new())
+                    values: Vec::new()
                 }
             )
         }
@@ -471,7 +470,7 @@ impl<'filename> Parser<'filename> {
             self.consume(TokenType::Rbrace)?;
             Ok(Node::Map {
                 location,
-                values: Box::new(nodes)
+                values: nodes
             })
         }
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -24,10 +24,10 @@ impl<'filename> Parser<'filename> {
     // блок
     fn block(&mut self) -> Result<Node, Error> {
         // список
-        let mut nodes: Vec<Box<Node>> = Vec::new();
+        let mut nodes: Vec<Node> = Vec::new();
         // до } или конца файла
         while !self.is_at_end() && !self.check(TokenType::Rbrace) {
-            nodes.push(Box::new(self.statement()?));
+            nodes.push(self.statement()?);
         }
         // возвращаем
         Ok(Node::Block {
@@ -36,21 +36,21 @@ impl<'filename> Parser<'filename> {
     }
 
     // аргументы
-    fn args(&mut self) -> Result<Vec<Box<Node>>, Error> {
+    fn args(&mut self) -> Result<Vec<Node>, Error> {
         // список
-        let mut nodes: Vec<Box<Node>> = Vec::new();
+        let mut nodes: Vec<Node> = Vec::new();
         // (
         self.consume(TokenType::Lparen)?;
         // до )
         if !self.check(TokenType::Rparen) {
             // аргумент
-            nodes.push(Box::new(self.expr()?));
+            nodes.push(self.expr()?);
             // через запятую
             while !self.is_at_end() && self.check(TokenType::Comma) {
                 // ,
                 self.consume(TokenType::Comma)?;
                 // аргумент
-                nodes.push(Box::new(self.expr()?));
+                nodes.push(self.expr()?);
             }
         }
         // )
@@ -408,7 +408,7 @@ impl<'filename> Parser<'filename> {
             Ok(
                 Node::List {
                     location,
-                    values: Box::new(Vec::new())
+                    values: Vec::new()
                 }
             )
         }
@@ -426,7 +426,7 @@ impl<'filename> Parser<'filename> {
             
             Ok(Node::List {
                 location,
-                values: Box::new(nodes)
+                values: nodes
             })
         }
     }
@@ -870,7 +870,7 @@ impl<'filename> Parser<'filename> {
                     ));
                 }
             }
-            body.push(Box::new(node));
+            body.push(node);
         }
         self.consume(TokenType::Rbrace)?;
         // возвращаем
@@ -984,7 +984,7 @@ impl<'filename> Parser<'filename> {
                     ));
                 }
             }
-            body.push(Box::new(node));
+            body.push(node);
         }
         // }
         self.consume(TokenType::Rbrace)?;

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -73,7 +73,7 @@ impl ImportsResolver {
         // компиляция
         let tokens = executor::lex(
             &filename,
-            code,
+            &code,
             false,
             false
         );
@@ -94,9 +94,9 @@ impl ImportsResolver {
             // новое тело
             let mut new_body: Vec<Node> = vec![];
             // добавляем в тело
-            for node in body {
+            for node in &body {
                 // перебираем
-                match node.clone() {
+                match node {
                     Node::Native { .. } |
                     Node::FnDeclaration { .. } |
                     Node::Type { .. } |

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -92,11 +92,11 @@ impl ImportsResolver {
         // проверяем блок
         if let Node::Block { body } = analyzed {
             // новое тело
-            let mut new_body: Vec<Box<Node>> = vec![];
+            let mut new_body: Vec<Node> = vec![];
             // добавляем в тело
             for node in body {
                 // перебираем
-                match *node.clone() {
+                match node.clone() {
                     Node::Native { .. } |
                     Node::FnDeclaration { .. } |
                     Node::Type { .. } |

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -88,10 +88,10 @@ impl Analyzer {
     }
 
     // блок
-    pub fn analyze_block(&mut self, body: Vec<Box<Node>>) {
+    pub fn analyze_block(&mut self, body: Vec<Node>) {
         // ноды
         for node in body {
-            self.analyze(*node);
+            self.analyze(node);
         }
     }
 
@@ -143,7 +143,7 @@ impl Analyzer {
     // break
     fn analyze_break(&mut self, addr: Address) {
         // проверяем
-        if self.analyze_stack.len() == 0 {
+        if self.analyze_stack.is_empty() {
             error!(Error::new(
                 addr,
                 "couldn't use break without loop.".to_string(),
@@ -172,7 +172,7 @@ impl Analyzer {
     // анализ ретурн
     fn analyze_return(&mut self, addr: Address) {
         // проверяем
-        if self.analyze_stack.len() == 0 {
+        if self.analyze_stack.is_empty() {
             error!(Error::new(
                 addr,
                 "couldn't use return without loop.".to_string(),


### PR DESCRIPTION
I usually run this command to measure memory usage:
```
valgrind --tool=memcheck target/debug/Watt <program here>
```

Memory change (`vyacheslavhere/main` -> `NDRAEY/refactors`): `1 113 933` -> `1 087 126` (diff `-26 807` bytes)

This is a draft because I plan new wave of optimizations on `compiler/visitor` level.