### PR TITLE
Add new files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 target/
+flamegraph.svg
+perf.data*


### PR DESCRIPTION
Those are used in `flamegraph` and `perf` to profile Watt compiler/interpreter.