### PR TITLE
Make `error!` never return

### DIFF
--- a/src/errors/errors.rs
+++ b/src/errors/errors.rs
@@ -59,7 +59,7 @@ impl Error {
     }
     
     // вывод
-    pub fn panic(&self) {
+    pub fn panic(&self) -> ! {
         let filename = self.addr.file.as_ref().map_or("-", |v| v);
         let textline = self.addr.line_text.as_ref().map_or("-", |v| v);
 

--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -172,8 +172,6 @@ pub fn parse(file_name: &str, tokens: Vec<Token>,
     } else if let Err(error) = raw_ast {
         // ошибка
         error!(error);
-        // ничего не возвращаем
-        return None
     };
     // паника
     panic!("result error in parsing. report to developer.")

--- a/src/semantic/analyzer.rs
+++ b/src/semantic/analyzer.rs
@@ -202,7 +202,6 @@ impl Analyzer {
                 "couldn't use continue without loop.",
                 "remove this keyword"
             ));
-            return;
         }
         // проверяем loop
         if !self.hierarchy_has_loop() {
@@ -223,7 +222,6 @@ impl Analyzer {
                 "couldn't use break without loop.",
                 "remove this keyword"
             ));
-            return;
         }
         // проверяем loop
         if !self.hierarchy_has_loop() {
@@ -252,7 +250,6 @@ impl Analyzer {
                 "couldn't use return without loop.",
                 "remove this keyword"
             ));
-            return;
         }
         // проверяем fn
         if !self.hierarchy_has_fn() {

--- a/src/vm/natives/libs/natives_base.rs
+++ b/src/vm/natives/libs/natives_base.rs
@@ -46,8 +46,6 @@ pub unsafe fn provide(built_in_address: Address, vm: &mut VM) -> Result<(), Erro
                     "check your code."
                 ))
             }
-            // успех
-            Ok(())
         }
     );
     // успех

--- a/src/vm/natives/libs/utils.rs
+++ b/src/vm/natives/libs/utils.rs
@@ -16,7 +16,6 @@ pub fn expect_int(addr: Address, value: Value, error: Option<Error>) ->i64 {
             format!("expected int, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -31,7 +30,6 @@ pub fn expect_float(addr: Address, value: Value, error: Option<Error>) ->f64 {
             format!("expected float, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -46,7 +44,6 @@ pub fn expect_bool(addr: Address, value: Value, error: Option<Error>) ->bool {
             format!("expected bool, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -61,7 +58,6 @@ pub fn expect_instance(addr: Address, value: Value, error: Option<Error>) ->*mut
             format!("expected instance, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -76,7 +72,6 @@ pub fn expect_unit(addr: Address, value: Value, error: Option<Error>) ->*mut Uni
             format!("expected unit, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -91,7 +86,6 @@ pub fn expect_trait(addr: Address, value: Value, error: Option<Error>) ->*mut Tr
             format!("expected trait, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -106,7 +100,6 @@ pub fn expect_type(addr: Address, value: Value, error: Option<Error>) ->*mut Typ
             format!("expected type, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -121,7 +114,6 @@ pub fn expect_fn(addr: Address, value: Value, error: Option<Error>) ->*mut Funct
             format!("expected fn, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -136,7 +128,6 @@ pub fn expect_native(addr: Address, value: Value, error: Option<Error>) ->*mut N
             format!("expected native, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -151,7 +142,6 @@ pub fn expect_any(addr: Address, value: Value, error: Option<Error>) ->*mut dyn 
             format!("expected any, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -166,7 +156,6 @@ pub fn expect_string(addr: Address, value: Value, error: Option<Error>) ->*const
             format!("expected string, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }
 
@@ -182,6 +171,5 @@ pub fn expect_list(addr: Address, value: Value, error: Option<Error>) ->*mut Vec
             format!("expected list, got {:?}", value),
             "check for types"
         )));
-        unreachable!();
     }
 }

--- a/src/vm/vm.rs
+++ b/src/vm/vm.rs
@@ -1057,7 +1057,6 @@ impl VM {
                     ),
                     format!("expected {} arguments.", params_amount)
                 ));
-                Ok(())
             }
         }
 
@@ -1084,7 +1083,6 @@ impl VM {
                     ),
                     format!("expected {} arguments.", params_amount)
                 ));
-                Ok(())
             }
         }
 
@@ -1180,7 +1178,6 @@ impl VM {
                 format!("{name} is not a fn."),
                 "you can call only fn-s."
             ));
-            Ok(())
         }
     }
 
@@ -1268,7 +1265,6 @@ impl VM {
             // проверяем результат
             if let Err(e) = trait_result {
                 error!(e);
-                None
             }
             else if let Ok(trait_value) = trait_result {
                 match trait_value {
@@ -1292,7 +1288,6 @@ impl VM {
             // проверяем результат
             if let Err(e) = fn_result {
                 error!(e);
-                None
             }
             else if let Ok(trait_value) = fn_result {
                 return match trait_value {
@@ -1422,7 +1417,6 @@ impl VM {
                     format!("invalid args amount: {} to create instance of {}.", passed_amount, name),
                     format!("expected {} arguments.", params_amount)
                 ));
-                Ok(())
             }
         }
         // ищем тип
@@ -1494,7 +1488,6 @@ impl VM {
         }
         else {
             error!(lookup_result.unwrap_err());
-            Ok(())
         }
     }
 
@@ -1554,7 +1547,6 @@ impl VM {
                             format!("is_ok takes {} params", (*function).params.len()),
                             "is_ok should take 0 params."
                         ));
-                        return Ok(false);
                     }
                 }
                 // если нет
@@ -1564,7 +1556,6 @@ impl VM {
                             "is_ok is not a fn.",
                             "is_ok should be fn."
                         ));
-                    return Ok(false);
                 }
                 // вызываем
                 vm.call(
@@ -1584,13 +1575,11 @@ impl VM {
                         "is_ok should return a bool.".to_string(),
                         format!("it returned: {is_ok:?}")
                     ));
-                    Ok(false)
                 }
             }
             // если ошибка
             else if let Err(e) = lookup_result {
                 error!(e);
-                return Ok(false)
             }
             // dead code
             Ok(false)
@@ -1611,7 +1600,6 @@ impl VM {
                                 format!("unwrap takes {} params", (*function).params.len()),
                                 "unwrap should take 0 params."
                             ));
-                            return Ok(());
                         }
                     }
                     // если нет
@@ -1621,7 +1609,6 @@ impl VM {
                             "unwrap is not a fn.",
                             "unwrap should be fn."
                         ));
-                        return Ok(());
                     }
                     // вызываем
                     vm.call(
@@ -1636,8 +1623,6 @@ impl VM {
                 Err(e) => {
                     // ошибка
                     error!(e);
-                    // успех
-                    Ok(())
                 }
             }
         }


### PR DESCRIPTION
Because of `std::process::exit(1)` at `Error::error`'s end.