### PR TITLE
Simplify Clap parameters

### DIFF
--- a/src/cli/cli.rs
+++ b/src/cli/cli.rs
@@ -12,29 +12,29 @@ struct CLI {
     #[arg(long = "gc-threshold", value_name = "gc_threshold")]
     gc_threshold: Option<usize>,
 
-    #[arg(long = "gc-debug", value_name = "gc_debug")]
-    gc_debug: Option<bool>,
+    #[arg(long = "gc-debug", default_value_t=false)]
+    gc_debug: bool,
 
-    #[arg(long = "ast-debug", value_name = "ast_debug")]
-    ast_debug: Option<bool>,
+    #[arg(long = "ast-debug", default_value_t=false)]
+    ast_debug: bool,
 
-    #[arg(long = "opcodes-debug", value_name = "opcodes_debug")]
-    opcodes_debug: Option<bool>,
+    #[arg(long = "opcodes-debug", default_value_t=false)]
+    opcodes_debug: bool,
 
-    #[arg(long = "lexer-debug", value_name = "lexer_debug")]
-    lexer_debug: Option<bool>,
+    #[arg(long = "lexer-debug", default_value_t=false)]
+    lexer_debug: bool,
 
-    #[arg(long = "parse-bench", value_name = "parse_bench")]
-    parse_bench: Option<bool>,
+    #[arg(long = "parse-bench", default_value_t=false)]
+    parse_bench: bool,
 
-    #[arg(long = "compile-bench", value_name = "compile_bench")]
-    compile_bench: Option<bool>,
+    #[arg(long = "compile-bench", default_value_t=false)]
+    compile_bench: bool,
 
-    #[arg(long = "lexer-bench", value_name = "lexer_bench")]
-    lexer_bench: Option<bool>,
+    #[arg(long = "lexer-bench", default_value_t=false)]
+    lexer_bench: bool,
 
-    #[arg(long = "runtime-bench", value_name = "runtime_bench")]
-    runtime_bench: Option<bool>,
+    #[arg(long = "runtime-bench", default_value_t=false)]
+    runtime_bench: bool,
 }
 
 pub unsafe fn cli() {

--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -17,14 +17,14 @@ use crate::vm::vm::{VmSettings, VM};
 pub unsafe fn run(
     path: PathBuf,
     gc_threshold: Option<usize>,
-    gc_debug: Option<bool>,
-    lexer_debug: Option<bool>,
-    ast_debug: Option<bool>,
-    opcodes_debug: Option<bool>,
-    lexer_bench: Option<bool>,
-    parser_bench: Option<bool>,
-    compile_bench: Option<bool>,
-    runtime_bench: Option<bool>,
+    gc_debug: bool,
+    lexer_debug: bool,
+    ast_debug: bool,
+    opcodes_debug: bool,
+    lexer_bench: bool,
+    parser_bench: bool,
+    compile_bench: bool,
+    runtime_bench: bool,
 ) {
     // чтение файла
     let code = read_file(Option::None, &path);
@@ -34,14 +34,14 @@ pub unsafe fn run(
     let tokens = lex(
         filename,
         &code.chars().collect::<Vec<char>>(),
-        lexer_debug.unwrap_or(false),
-        lexer_bench.unwrap_or(false)
+        lexer_debug,
+        lexer_bench
     );
     let ast = parse(
         filename,
         tokens.unwrap(),
-        ast_debug.unwrap_or(false),
-        parser_bench.unwrap_or(false),
+        ast_debug,
+        parser_bench,
         &None
     );
     let analyzed = analyze(
@@ -49,15 +49,15 @@ pub unsafe fn run(
     );
     let compiled = compile(
         &analyzed,
-        opcodes_debug.unwrap_or(false),
-        compile_bench.unwrap_or(false)
+        opcodes_debug,
+        compile_bench
     );
     // запуск
     run_chunk(
         compiled,
         gc_threshold.unwrap_or(200),
-        gc_debug.unwrap_or(false),
-        runtime_bench.unwrap_or(false)
+        gc_debug,
+        runtime_bench
     );
 }
 


### PR DESCRIPTION
Now, there's no need to write `true` after each parameter. If flag isn't provided, it will be false. This approach saves command line space and looks more efficient.