### PR TITLE
Get rid of Address::line_text

### DIFF
--- a/src/errors/errors.rs
+++ b/src/errors/errors.rs
@@ -16,7 +16,7 @@ pub struct Error {
 macro_rules! error {
     ($err:expr) => {
         $err.panic()
-    }
+    };
 }
 
 // имплементация
@@ -47,7 +47,7 @@ impl Error {
             hint: Cow::Borrowed(hint),
         }
     }
-    
+
     // новая ошибка
     #[allow(unused)]
     pub fn own_hint(addr: Address, text: &'static str, hint: String) -> Self {
@@ -57,10 +57,16 @@ impl Error {
             hint: Cow::Owned(hint),
         }
     }
-    
+
     // вывод
     pub fn panic(&self) -> ! {
-        let filename = self.addr.file.as_ref().map_or("-", |v| v);
+        let filename = self
+            .addr
+            .file
+            .as_ref()
+            .and_then(|x| x.file_name())
+            .and_then(|x| x.to_str().map(|y| y.to_string()))
+            .unwrap_or(String::from("-"));
         let text_line = self.addr.get_line().unwrap_or(String::from("-"));
 
         // выводим
@@ -72,16 +78,17 @@ impl Error {
         );
         println!("│");
         println!("│ {}:", filename);
-        println!("│ {gray}{line}{reset} {text}",
-                 line = self.addr.line,
-                 text = text_line,
-                 gray = colors::WhiteColor,
-                 reset = colors::ResetColor,
+        println!(
+            "│ {gray}{line}{reset} {text}",
+            line = self.addr.line,
+            text = text_line,
+            gray = colors::WhiteColor,
+            reset = colors::ResetColor,
         );
-        println!("│ {space:count$}^",
-                 space = " ",
-                 count = self.addr.column as usize
-                     + self.addr.line.to_string().len()
+        println!(
+            "│ {space:count$}^",
+            space = " ",
+            count = self.addr.column as usize + self.addr.line.to_string().len()
         );
         println!("│");
         println!("│ hint: {hint}", hint = self.hint);

--- a/src/errors/errors.rs
+++ b/src/errors/errors.rs
@@ -61,7 +61,7 @@ impl Error {
     // вывод
     pub fn panic(&self) -> ! {
         let filename = self.addr.file.as_ref().map_or("-", |v| v);
-        let text_line = self.addr.line_text.as_ref().map_or("-", |v| v);
+        let text_line = self.addr.get_line().unwrap_or(String::from("-"));
 
         // выводим
         println!(

--- a/src/lexer/address.rs
+++ b/src/lexer/address.rs
@@ -1,19 +1,33 @@
-﻿// адрес
+﻿use std::io::Read;
+
+// адрес
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Address {
     pub line: u64,
     pub column: u16,
     pub file: Option<String>,
-    pub line_text: Option<String>,
 }
+
 // имплементация
 impl Address {
     pub fn new(line: u64, column: u16,
-               file: String, line_text: String) -> Address {
-        Address { line, column, file: Some(file), line_text: Some(line_text) }
+               file: String) -> Address {
+        Address { line, column, file: Some(file) }
     }
 
     pub fn unknown() -> Address {
-        Address { line: 0, column: 0, file: None, line_text: None }
+        Address { line: 0, column: 0, file: None }
+    }
+
+    pub fn get_line(&self) -> Option<String> {
+        let filepath = self.file.as_ref()?;
+
+        let mut file = std::fs::OpenOptions::new().read(true).open(filepath).ok()?;
+
+        let mut string = String::new();
+
+        file.read_to_string(&mut string).ok()?;
+        
+        return string.split('\n').nth(self.line as usize + 1).map(String::from);
     }
 }

--- a/src/lexer/address.rs
+++ b/src/lexer/address.rs
@@ -1,17 +1,17 @@
-﻿use std::io::Read;
+﻿use std::{io::Read, path::PathBuf};
 
 // адрес
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct Address {
     pub line: u64,
     pub column: u16,
-    pub file: Option<String>,
+    pub file: Option<PathBuf>,
 }
 
 // имплементация
 impl Address {
     pub fn new(line: u64, column: u16,
-               file: String) -> Address {
+               file: PathBuf) -> Address {
         Address { line, column, file: Some(file) }
     }
 
@@ -23,11 +23,10 @@ impl Address {
         let filepath = self.file.as_ref()?;
 
         let mut file = std::fs::OpenOptions::new().read(true).open(filepath).ok()?;
-
         let mut string = String::new();
 
-        file.read_to_string(&mut string).ok()?;
+        file.read_to_string(&mut string).ok()?;        
         
-        return string.split('\n').nth(self.line as usize + 1).map(String::from);
+        return string.split('\n').nth(self.line as usize - 1).map(String::from);
     }
 }

--- a/src/lexer/address.rs
+++ b/src/lexer/address.rs
@@ -1,4 +1,4 @@
-﻿use std::{io::Read, path::PathBuf};
+﻿use std::{io::{BufRead, Read}, path::PathBuf};
 
 // адрес
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
@@ -22,11 +22,9 @@ impl Address {
     pub fn get_line(&self) -> Option<String> {
         let filepath = self.file.as_ref()?;
 
-        let mut file = std::fs::OpenOptions::new().read(true).open(filepath).ok()?;
-        let mut string = String::new();
+        let file = std::fs::OpenOptions::new().read(true).open(filepath).ok()?;
+        let reader = std::io::BufReader::new(file);
 
-        file.read_to_string(&mut string).ok()?;        
-        
-        return string.split('\n').nth(self.line as usize - 1).map(String::from);
+        reader.lines().nth(self.line as usize - 1)?.ok()
     }
 }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -93,7 +93,6 @@ pub struct Lexer<'filename, 'cursor> {
     line: u64,
     column: u16,
     cursor: Cursor<'cursor>,
-    line_text: String,
     filename: &'filename str,
     tokens: Vec<Token>,
     keywords: HashMap<&'static str, TokenType>,
@@ -135,14 +134,11 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
         let mut lexer = Lexer {
             line: 1,
             column: 0,
-            line_text: String::new(),
             cursor: Cursor::new(code),
             filename,
             tokens: vec![],
             keywords: map,
         };
-        // текст первой линии
-        lexer.line_text = lexer.get_line_text();
         // возвращаем
         lexer
     }
@@ -326,7 +322,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                                 self.line,
                                 self.column,
                                 self.filename.to_string(),
-                                self.line_text.clone(),
                             ),
                             format!("unexpected char: {}", ch),
                             format!("delete char: {}", ch),
@@ -358,7 +353,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                         self.line,
                         self.column,
                         self.filename.to_string(),
-                        self.line_text.clone(),
                     ),
                     "unclosed string quotes.",
                     "did you forget ' symbol?",
@@ -375,7 +369,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                 self.line,
                 self.column,
                 self.filename.to_string(),
-                self.line_text.clone(),
             ),
         })
     }
@@ -394,7 +387,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                             self.line,
                             self.column,
                             self.filename.to_string(),
-                            self.line_text.clone(),
                         ),
                         "couldn't parse number with two dots",
                         "check your code.",
@@ -416,7 +408,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                 self.line,
                 self.column,
                 self.filename.to_string(),
-                self.line_text.clone(),
             ),
         })
     }
@@ -440,28 +431,13 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                 self.line,
                 self.column,
                 self.filename.to_string(),
-                self.line_text.clone(),
             ),
         }
-    }
-
-
-    fn get_line_text(&self) -> String {
-        // проходимся по тексту
-        let mut i = 0;
-        let mut line_text = String::new();
-        while !self.cursor.is_at_end_offset(i) && self.cursor.char_at(i) != '\n' {
-            line_text.push(self.cursor.char_at(i));
-            i += 1;
-        }
-        // возвращаем
-        line_text
     }
 
     fn newline(&mut self) {
         self.line += 1;
         self.column = 0;
-        self.line_text = self.get_line_text();
     }
 
     fn advance(&mut self) -> char {
@@ -491,7 +467,6 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                 self.line,
                 self.column,
                 self.filename.to_string(),
-                self.line_text.clone(),
             ),
         ));
     }

--- a/src/lexer/lexer.rs
+++ b/src/lexer/lexer.rs
@@ -3,6 +3,7 @@ use crate::error;
 use crate::errors::errors::Error;
 use crate::lexer::address::*;
 use std::collections::HashMap;
+use std::path::PathBuf;
 use crate::lexer::cursor::Cursor;
 
 // тип токена
@@ -89,18 +90,18 @@ impl Token {
 }
 
 // лексер
-pub struct Lexer<'filename, 'cursor> {
+pub struct Lexer<'filepath, 'cursor> {
     line: u64,
     column: u16,
     cursor: Cursor<'cursor>,
-    filename: &'filename str,
+    filepath: &'filepath PathBuf,
     tokens: Vec<Token>,
     keywords: HashMap<&'static str, TokenType>,
 }
 
 // имплементация
-impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
-    pub fn new(code: &'cursor [char], filename: &'filename str) -> Self {
+impl<'filepath, 'cursor> Lexer<'filepath, 'cursor> {
+    pub fn new(code: &'cursor [char], filepath: &'filepath PathBuf) -> Self {
         let map = HashMap::from([
             ("fun", TokenType::Fun),
             ("break", TokenType::Break),
@@ -130,17 +131,15 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
             ("native", TokenType::Native),
             ("impls", TokenType::Impls),
         ]);
-        // лексер
-        let mut lexer = Lexer {
+        // возвращаем лексер
+        Lexer {
             line: 1,
             column: 0,
             cursor: Cursor::new(code),
-            filename,
+            filepath,
             tokens: vec![],
             keywords: map,
-        };
-        // возвращаем
-        lexer
+        }
     }
 
     pub fn lex(mut self) -> Vec<Token> {
@@ -321,7 +320,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                             Address::new(
                                 self.line,
                                 self.column,
-                                self.filename.to_string(),
+                                self.filepath.clone(),
                             ),
                             format!("unexpected char: {}", ch),
                             format!("delete char: {}", ch),
@@ -352,7 +351,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                     Address::new(
                         self.line,
                         self.column,
-                        self.filename.to_string(),
+                        self.filepath.clone(),
                     ),
                     "unclosed string quotes.",
                     "did you forget ' symbol?",
@@ -368,7 +367,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.to_string(),
+                self.filepath.clone(),
             ),
         })
     }
@@ -386,7 +385,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
                         Address::new(
                             self.line,
                             self.column,
-                            self.filename.to_string(),
+                            self.filepath.clone(),
                         ),
                         "couldn't parse number with two dots",
                         "check your code.",
@@ -407,7 +406,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.to_string(),
+                self.filepath.clone(),
             ),
         })
     }
@@ -430,7 +429,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
             address: Address::new(
                 self.line,
                 self.column,
-                self.filename.to_string(),
+                self.filepath.clone(),
             ),
         }
     }
@@ -466,7 +465,7 @@ impl<'filename, 'cursor> Lexer<'filename, 'cursor> {
             Address::new(
                 self.line,
                 self.column,
-                self.filename.to_string(),
+                self.filepath.clone(),
             ),
         ));
     }

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1340,8 +1340,7 @@ impl<'filename, 'prefix> Parser<'filename, 'prefix> {
                     Address::new(
                         0,
                         0,
-                        self.filename.to_string(),
-                        "eof".to_string()
+                        self.filename.to_string()
                     ),
                     "unexpected eof",
                     "check your code."
@@ -1378,7 +1377,6 @@ impl<'filename, 'prefix> Parser<'filename, 'prefix> {
                         0,
                         0,
                         self.filename.to_string(),
-                        "eof".to_string()
                     ),
                     "unexpected eof",
                     "check your code."

--- a/src/parser/parser.rs
+++ b/src/parser/parser.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 // импорты
 use crate::lexer::address::*;
 use crate::errors::errors::{Error};
@@ -10,14 +12,14 @@ use crate::error;
 pub struct Parser<'filename, 'prefix> {
     tokens: Vec<Token>,
     current: u128,
-    filename: &'filename str,
+    filename: &'filename PathBuf,
     full_name_prefix: &'prefix str,
 }
 // имплементация
 #[allow(unused_qualifications)]
 impl<'filename, 'prefix> Parser<'filename, 'prefix> {
     // новый
-    pub fn new(tokens: Vec<Token>, filename: &'filename str, full_name_prefix: &'prefix str) -> Self {
+    pub fn new(tokens: Vec<Token>, filename: &'filename PathBuf, full_name_prefix: &'prefix str) -> Self {
         Parser { tokens, current: 0, filename, full_name_prefix }
     }
     
@@ -1340,7 +1342,7 @@ impl<'filename, 'prefix> Parser<'filename, 'prefix> {
                     Address::new(
                         0,
                         0,
-                        self.filename.to_string()
+                        self.filename.clone()
                     ),
                     "unexpected eof",
                     "check your code."
@@ -1376,7 +1378,7 @@ impl<'filename, 'prefix> Parser<'filename, 'prefix> {
                     Address::new(
                         0,
                         0,
-                        self.filename.to_string(),
+                        self.filename.clone(),
                     ),
                     "unexpected eof",
                     "check your code."

--- a/src/resolver/resolver.rs
+++ b/src/resolver/resolver.rs
@@ -74,16 +74,16 @@ impl<'import_key, 'import_path> ImportsResolver<'import_key, 'import_path> {
         // чтение файла
         let code = executor::read_file(addr, &path);
         // имя файла
-        let filename = path.file_name().unwrap().to_str().unwrap();
+        // let filename = path.file_name().unwrap().to_str().unwrap();
         // компиляция
         let tokens = executor::lex(
-            filename,
+            &path,
             &code.chars().collect::<Vec<char>>(),
             false,
             false
         );
         let ast = executor::parse(
-            filename,
+            &path,
             tokens.unwrap(),
             false,
             false,


### PR DESCRIPTION
It saves CPU time taken by cloning `Lexer::line_text` on EACH token, and reduces memory usage by ~300 KB.

Memory usage on `vyacheslavhere/main`: 1,832,113 bytes (21,677 allocs, 21,669 frees)
Memory usage on `NDRAEY/no-linetext`: 1,499,880 bytes (15,961 allocs, 15,953 frees)