### PR TITLE
Create and use owned version of VM::run to avoid unnecessary clones

### DIFF
--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -255,7 +255,7 @@ unsafe fn run_chunk(chunk: Chunk, gc_threshold: usize, gc_debug: bool, bench: bo
     ));
     
     // handling errors
-    if let Err(e) = vm.run(&chunk, vm.globals) {
+    if let Err(e) = vm.run_owned(chunk, vm.globals) {
         error!(Error::own_text(
             Address::unknown(),
             format!("control flow leak: {e:?}"),

--- a/src/vm/bytecode.rs
+++ b/src/vm/bytecode.rs
@@ -12,11 +12,17 @@ impl Chunk {
     pub fn new(chunk: Vec<Opcode>) -> Self {
         Chunk { opcodes: chunk }
     }
+    
     pub fn of(op: Opcode) -> Self {
         Chunk { opcodes: vec![op] }
     }
+
     pub fn opcodes(&self) -> &Vec<Opcode> {
         &self.opcodes
+    }
+
+    pub fn into_opcodes(self) -> Vec<Opcode> {
+        self.opcodes
     }
 }
 

--- a/src/vm/table.rs
+++ b/src/vm/table.rs
@@ -63,12 +63,12 @@ impl Table {
         }
     }
 
-    pub unsafe fn set(&mut self, address: Address, name: &str, value: Value) -> Result<(), Error> {
+    pub unsafe fn set(&mut self, address: &Address, name: &str, value: Value) -> Result<(), Error> {
         let mut current = self as *mut Table;
         while !(*current).fields.contains_key(name) {
             if (*current).root.is_null() {
                 return Err(Error::own_text(
-                    address,
+                    address.clone(),
                     format!("{name} is not defined."),
                     "you can define it, using := op."
                 ))


### PR DESCRIPTION
This function uses moved values instead of referencing, so it avoids cloning when the value itself is needed.