### PR TITLE
Extend external library search paths

### DIFF
--- a/src/executor/executor.rs
+++ b/src/executor/executor.rs
@@ -92,6 +92,22 @@ pub fn crash(reason: String) -> ! {
 /// or file can not be read.
 ///
 pub fn read_file(addr: Option<Address>, path: &PathBuf) -> String {
+    // If path already exist, pass it
+    let path = if path.exists() {
+        path
+    } else {
+        // If not, so we take the directory path of our program that imports the file
+        let mut rpath = addr
+            .as_ref()
+            .and_then(|x| x.file.as_ref()).unwrap()
+            .parent().map(|x| x.to_path_buf()).unwrap();
+
+        // And add library name to it.
+        rpath.push(path);
+
+        &rpath.clone()
+    };
+
     if path.exists() {
         if let Ok(result) = fs::read_to_string(path) {
             result
@@ -103,12 +119,7 @@ pub fn read_file(addr: Option<Address>, path: &PathBuf) -> String {
                         "check file existence"
                     ));
             } else {
-                crash(
-                    format!(
-                        "file not found: {:?}",
-                        path
-                    )
-                );
+                crash(format!("file not found: {:?}", path));
             }
         }
     }
@@ -120,12 +131,7 @@ pub fn read_file(addr: Option<Address>, path: &PathBuf) -> String {
                     "check file existence"
                 ));
         } else {
-            crash(
-                format!(
-                    "file not found: {:?}",
-                    path
-                )
-            );
+            crash(format!("file not found: {:?}", path));
         }
     }
 }


### PR DESCRIPTION
How it worked before:
1. We search for a library in local path (cwd + library path)
2. If not found, throw an error.

How it works now:
1. We search for a library in local path (cwd + library path)
2. If not found, we search in program's directory (progdir + library path)
3. If not found, throw an error.

It adds support to run programs that use local imports from foreign directories.