### PR TITLE
Fix typo in chapter_1.md: main.rs to main.wt at line 22

### DIFF
--- a/docs/src/chapter_1.md
+++ b/docs/src/chapter_1.md
@@ -19,7 +19,7 @@ my_project
   /main.wt
 ```
 
-Now open the main.rs file and let's write our first program, traditional 'Hello, world!'
+Now open the main.wt file and let's write our first program, traditional 'Hello, world!'
 
 *main.wt:*
 ```watt


### PR DESCRIPTION
Fixes a small but critical typo in the beginner's guide. Replaces `main.rs` with the correct Watt language file extension `main.wt` to avoid user confusion when creating their first script.